### PR TITLE
make the functionality of totalPrincipalTokensRepaid over time more consistent

### DIFF
--- a/packages/contracts/contracts/LenderCommitmentForwarder/extensions/LenderCommitmentGroup/LenderCommitmentGroup_Smart.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/extensions/LenderCommitmentGroup/LenderCommitmentGroup_Smart.sol
@@ -517,7 +517,7 @@ contract LenderCommitmentGroup_Smart is
 
             tokenDifferenceFromLiquidations -= int256(tokensToGiveToSender);
 
-            totalPrincipalTokensRepaid += (amountDue - tokensToGiveToSender);
+            totalPrincipalTokensRepaid += amountDue;
         }
 
         //this will give collateral to the caller


### PR DESCRIPTION
Still need to make sure that the behavior of 'totalPrincipalTokensRepaid' over time through many liquidations and normal repayments keeps the accounting consistent for lender deposits and withdraws and the shares that will constitute. 