### PR TITLE
Pauser Roles 

### DIFF
--- a/packages/contracts/contracts/CollateralManager.sol
+++ b/packages/contracts/contracts/CollateralManager.sol
@@ -78,9 +78,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
         _;
     }
 
-    modifier whenProtocolNotPaused() {
-
-        
+    modifier whenProtocolNotPaused() {        
         require( PausableUpgradeable(address(tellerV2)).paused() == false , "Protocol is paused");
         _;
     }

--- a/packages/contracts/contracts/CollateralManager.sol
+++ b/packages/contracts/contracts/CollateralManager.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 // Libraries
 import "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
-
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 // Interfaces
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
@@ -70,11 +70,18 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
         _;
     }
 
-     modifier onlyProtocolOwner() {
+    modifier onlyProtocolOwner() {
 
         address protocolOwner = OwnableUpgradeable(address(tellerV2)).owner();
 
         require(_msgSender() == protocolOwner, "Sender not authorized");
+        _;
+    }
+
+    modifier whenProtocolNotPaused() {
+
+        
+        require( PausableUpgradeable(address(tellerV2)).paused() == false , "Protocol is paused");
         _;
     }
 
@@ -262,7 +269,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
      * @notice Withdraws deposited collateral from the created escrow of a bid that has been successfully repaid.
      * @param _bidId The id of the bid to withdraw collateral for.
      */
-    function withdraw(uint256 _bidId) external {
+    function withdraw(uint256 _bidId) external whenProtocolNotPaused {
         BidState bidState = tellerV2.getBidState(_bidId);
 
         require(bidState == BidState.PAID, "collateral cannot be withdrawn");
@@ -277,7 +284,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
         address _tokenAddress, 
         uint256 _amount,
         address _recipientAddress
-        ) external onlyProtocolOwner {
+        ) external onlyProtocolOwner whenProtocolNotPaused {
 
             ICollateralEscrowV1(_escrows[_bidId]).withdrawDustTokens(
                     _tokenAddress,
@@ -290,7 +297,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
      * @notice Withdraws deposited collateral from the created escrow of a bid that has been CLOSED after being defaulted.
      * @param _bidId The id of the bid to withdraw collateral for.
      */
-    function lenderClaimCollateral(uint256 _bidId) external onlyTellerV2 {
+    function lenderClaimCollateral(uint256 _bidId) external onlyTellerV2 whenProtocolNotPaused {
         if (isBidCollateralBacked(_bidId)) {
             BidState bidState = tellerV2.getBidState(_bidId);
 
@@ -308,7 +315,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
      * @notice Withdraws deposited collateral from the created escrow of a bid that has been CLOSED after being defaulted.
      * @param _bidId The id of the bid to withdraw collateral for.
      */
-      function lenderClaimCollateralWithRecipient(uint256 _bidId, address _collateralRecipient) external onlyTellerV2 {
+      function lenderClaimCollateralWithRecipient(uint256 _bidId, address _collateralRecipient) external onlyTellerV2  whenProtocolNotPaused {
         if (isBidCollateralBacked(_bidId)) {
             BidState bidState = tellerV2.getBidState(_bidId);
 
@@ -331,6 +338,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
     function liquidateCollateral(uint256 _bidId, address _liquidatorAddress)
         external
         onlyTellerV2
+        whenProtocolNotPaused
     {
         if (isBidCollateralBacked(_bidId)) {
             BidState bidState = tellerV2.getBidState(_bidId);

--- a/packages/contracts/contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol
@@ -15,7 +15,7 @@ import { CommitmentCollateralType, ISmartCommitment } from "../interfaces/ISmart
 contract SmartCommitmentForwarder is
     ExtensionsContextUpgradeable, //this should always be first for upgradeability
     TellerV2MarketForwarder_G3,
-    PausableUpgradeable,  //this does add some storage 
+    PausableUpgradeable,  //this does add some storage but AFTER all other storage
     ISmartCommitmentForwarder
      {
     event ExercisedSmartCommitment(
@@ -29,9 +29,8 @@ contract SmartCommitmentForwarder is
 
 
 
-    modifier onlyProtocolPauser() {
- 
-        require( ITellerV2( _protocolAddress ).isPauser(_msgSender()) , "Sender not authorized");
+    modifier onlyProtocolPauser() { 
+        require( ITellerV2( _tellerV2 ).isPauser(_msgSender()) , "Sender not authorized");
         _;
     }
 
@@ -39,7 +38,12 @@ contract SmartCommitmentForwarder is
 
     constructor(address _protocolAddress, address _marketRegistry)
         TellerV2MarketForwarder_G3(_protocolAddress, _marketRegistry)
-    {}
+    {  }
+
+    function initialize() public initializer {       
+        __Pausable_init();
+    }
+
 
     /**
      * @notice Accept the commitment to submitBid and acceptBid using the funds
@@ -63,7 +67,7 @@ contract SmartCommitmentForwarder is
         address _recipient,
         uint16 _interestRate,
         uint32 _loanDuration
-    ) public returns (uint256 bidId) {
+    ) public whenNotPaused returns (uint256 bidId) {
         require(
             ISmartCommitment(_smartCommitmentAddress)
                 .getCollateralTokenType() <=
@@ -174,6 +178,23 @@ contract SmartCommitmentForwarder is
     }
 
 
+
+    /**
+     * @notice Lets the DAO/owner of the protocol implement an emergency stop mechanism.
+     */
+    function pause() public virtual onlyProtocolPauser whenNotPaused {
+        _pause();
+    }
+
+    /**
+     * @notice Lets the DAO/owner of the protocol undo a previously implemented emergency stop.
+     */
+    function unpause() public virtual onlyProtocolPauser whenPaused {
+        _unpause();
+    }
+
+
+    // -----
 
         //Overrides
     function _msgSender()

--- a/packages/contracts/contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol
@@ -7,12 +7,15 @@ import "../interfaces/ILenderCommitmentForwarder.sol";
 import "../interfaces/ISmartCommitmentForwarder.sol";
 import "./LenderCommitmentForwarder_G1.sol";
 
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
 import { CommitmentCollateralType, ISmartCommitment } from "../interfaces/ISmartCommitment.sol";
 
  
 contract SmartCommitmentForwarder is
-   ExtensionsContextUpgradeable, //this should always be first for upgradeability
+    ExtensionsContextUpgradeable, //this should always be first for upgradeability
     TellerV2MarketForwarder_G3,
+    PausableUpgradeable,  //this does add some storage 
     ISmartCommitmentForwarder
      {
     event ExercisedSmartCommitment(
@@ -23,6 +26,16 @@ contract SmartCommitmentForwarder is
     );
 
     error InsufficientBorrowerCollateral(uint256 required, uint256 actual);
+
+
+
+    modifier onlyProtocolPauser() {
+ 
+        require( ITellerV2( _protocolAddress ).isPauser(_msgSender()) , "Sender not authorized");
+        _;
+    }
+
+
 
     constructor(address _protocolAddress, address _marketRegistry)
         TellerV2MarketForwarder_G3(_protocolAddress, _marketRegistry)

--- a/packages/contracts/contracts/LenderCommitmentForwarder/extensions/LenderCommitmentGroup/LenderCommitmentGroup_Smart.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/extensions/LenderCommitmentGroup/LenderCommitmentGroup_Smart.sol
@@ -210,6 +210,13 @@ contract LenderCommitmentGroup_Smart is
         _;
     }
 
+    modifier whenForwarderNotPaused() {
+         require( PausableUpgradeable(address(SMART_COMMITMENT_FORWARDER)).paused() == false , "Protocol is paused");
+        _;
+    }
+
+
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address _tellerV2,
@@ -374,7 +381,7 @@ contract LenderCommitmentGroup_Smart is
         uint256 _amount,
         address _sharesRecipient,
         uint256 _minSharesAmountOut
-    ) external returns (uint256 sharesAmount_) {
+    ) external whenForwarderNotPaused returns (uint256 sharesAmount_) {
         //transfers the primary principal token from msg.sender into this contract escrow
 
        
@@ -445,7 +452,7 @@ contract LenderCommitmentGroup_Smart is
         uint256 _collateralTokenId, 
         uint32 _loanDuration,
         uint16 _interestRate
-    ) external onlySmartCommitmentForwarder whenNotPaused {
+    ) external onlySmartCommitmentForwarder whenForwarderNotPaused {
         
         require(
             _collateralTokenAddress == address(collateralToken),
@@ -505,7 +512,7 @@ contract LenderCommitmentGroup_Smart is
 
     function prepareSharesForWithdraw(
         uint256 _amountPoolSharesTokens 
-    ) external returns (bool) {
+    ) external whenForwarderNotPaused returns (bool) {
         require( poolSharesToken.balanceOf(msg.sender) >= _amountPoolSharesTokens  );
 
         poolSharesPreparedToWithdrawForLender[msg.sender] = _amountPoolSharesTokens; 
@@ -523,7 +530,7 @@ contract LenderCommitmentGroup_Smart is
         uint256 _amountPoolSharesTokens,
         address _recipient,
         uint256 _minAmountOut
-    ) external returns (uint256) {
+    ) external whenForwarderNotPaused returns (uint256) {
        
         require(poolSharesPreparedToWithdrawForLender[msg.sender] >= _amountPoolSharesTokens,"Shares not prepared for withdraw");
         require(poolSharesPreparedTimestamp[msg.sender] <= block.timestamp - WITHDRAW_DELAY_TIME_SECONDS,"Shares not prepared for withdraw");
@@ -566,7 +573,7 @@ contract LenderCommitmentGroup_Smart is
     function liquidateDefaultedLoanWithIncentive(
         uint256 _bidId,
         int256 _tokenAmountDifference
-    ) public bidIsActiveForGroup(_bidId) {
+    ) public whenForwarderNotPaused bidIsActiveForGroup(_bidId) {
         
         //use original principal amount as amountDue
 
@@ -863,7 +870,7 @@ contract LenderCommitmentGroup_Smart is
         address repayer,
         uint256 principalAmount,
         uint256 interestAmount
-    ) external onlyTellerV2 {
+    ) external onlyTellerV2 whenForwarderNotPaused {
         //can use principal amt to increment amt paid back!! nice for math .
         totalPrincipalTokensRepaid += principalAmount;
         totalInterestCollected += interestAmount;
@@ -883,7 +890,7 @@ contract LenderCommitmentGroup_Smart is
         If principaltokens get stuck in the escrow vault for any reason, anyone may
         call this function to move them from that vault in to this contract 
     */
-    function withdrawFromEscrowVault ( uint256 _amount ) public  {
+    function withdrawFromEscrowVault ( uint256 _amount ) public whenForwarderNotPaused  {
 
 
         address _escrowVault = ITellerV2(TELLER_V2).getEscrowVault();

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -164,6 +164,16 @@ contract TellerV2 is
         _;
     }
 
+
+     modifier onlyPauser() {
+        if (pauserRoleBearer[_msgSender()] != true) {
+            revert  ( "Requires role: Pauser");
+        }
+
+        _;
+    }
+
+
     /** Constant Variables **/
 
     uint8 public constant CURRENT_CODE_VERSION = 10;
@@ -260,14 +270,14 @@ contract TellerV2 is
         // Check uri mapping first
         metadataURI_ = uris[_bidId];
         // If the URI is not present in the mapping
-        if (
+      /*  if (
             keccak256(abi.encodePacked(metadataURI_)) ==
             0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 // hardcoded constant of keccak256('')
         ) {
             // Return deprecated bytes32 uri as a string
             uint256 convertedURI = uint256(bids[_bidId]._metadataURI);
             metadataURI_ = StringsUpgradeable.toHexString(convertedURI, 32);
-        }
+        }*/
     }
 
     /**
@@ -443,7 +453,7 @@ contract TellerV2 is
      * @notice Function for a market owner to cancel a bid in the market.
      * @param _bidId The id of the bid to cancel.
      */
-    function marketOwnerCancelBid(uint256 _bidId) external {
+  /*  function marketOwnerCancelBid(uint256 _bidId) external {
         if (
             _msgSender() !=
             marketRegistry.getMarketOwner(bids[_bidId].marketplaceId)
@@ -456,7 +466,7 @@ contract TellerV2 is
         }
         _cancelBid(_bidId);
         emit MarketOwnerCancelledBid(_bidId);
-    }
+    }*/
 
     /**
      * @notice Function for users to cancel a bid.
@@ -710,16 +720,29 @@ contract TellerV2 is
     /**
      * @notice Lets the DAO/owner of the protocol implement an emergency stop mechanism.
      */
-    function pauseProtocol() public virtual onlyOwner whenNotPaused {
+    function pauseProtocol() public virtual onlyPauser whenNotPaused {
         _pause();
     }
 
     /**
      * @notice Lets the DAO/owner of the protocol undo a previously implemented emergency stop.
      */
-    function unpauseProtocol() public virtual onlyOwner whenPaused {
+    function unpauseProtocol() public virtual onlyPauser whenPaused {
         _unpause();
     }
+
+    function addPauser(address _pauser) public virtual onlyOwner   {
+       pauserRoleBearer[_pauser] = true;
+    }
+
+
+    function removePauser(address _pauser) public virtual onlyOwner {
+        pauserRoleBearer[_pauser] = false;
+    }
+
+
+
+
 
     function lenderCloseLoan(uint256 _bidId)
         external

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -166,9 +166,9 @@ contract TellerV2 is
 
 
      modifier onlyPauser() {
-        if (pauserRoleBearer[_msgSender()] != true) {
-            revert  ( "Requires role: Pauser");
-        }
+
+        require( pauserRoleBearer[_msgSender()] ||  owner() == _msgSender(), "Requires role: Pauser");
+       
 
         _;
     }
@@ -270,14 +270,14 @@ contract TellerV2 is
         // Check uri mapping first
         metadataURI_ = uris[_bidId];
         // If the URI is not present in the mapping
-      /*  if (
+        if (
             keccak256(abi.encodePacked(metadataURI_)) ==
             0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 // hardcoded constant of keccak256('')
         ) {
             // Return deprecated bytes32 uri as a string
             uint256 convertedURI = uint256(bids[_bidId]._metadataURI);
             metadataURI_ = StringsUpgradeable.toHexString(convertedURI, 32);
-        }*/
+        }
     }
 
     /**
@@ -884,9 +884,8 @@ contract TellerV2 is
             _borrowerBidsActive[bid.borrower].remove(_bidId);
 
             // If loan is is being liquidated and backed by collateral, withdraw and send to borrower
-            if (_shouldWithdrawCollateral) {
-
-                require( paused() == false, "Cannot withdraw collateral while protocol is paused." );
+            if (_shouldWithdrawCollateral) { 
+               
                 //   _getCollateralManagerForBid(_bidId).withdraw(_bidId);
                 collateralManager.withdraw(_bidId);
             }

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -174,6 +174,14 @@ contract TellerV2 is
     }
 
 
+    modifier whenLiquidationsNotPaused() {
+        require(!liquidationsPaused, "Liquidations are paused");
+      
+        _;
+    }
+
+
+
     /** Constant Variables **/
 
     uint8 public constant CURRENT_CODE_VERSION = 10;
@@ -718,18 +726,35 @@ contract TellerV2 is
     }
 
     /**
-     * @notice Lets the DAO/owner of the protocol implement an emergency stop mechanism.
+     * @notice Lets a pauser of the protocol implement an emergency stop mechanism.
      */
     function pauseProtocol() public virtual onlyPauser whenNotPaused {
         _pause();
     }
 
     /**
-     * @notice Lets the DAO/owner of the protocol undo a previously implemented emergency stop.
+     * @notice Lets a pauser of the protocol undo a previously implemented emergency stop.
      */
     function unpauseProtocol() public virtual onlyPauser whenPaused {
         _unpause();
     }
+
+
+     /**
+     * @notice Lets a pauser of the protocol implement an emergency stop mechanism.
+     */
+    function pauseLiquidations() public virtual onlyPauser {
+        liquidationsPaused = true;
+    }
+
+    /**
+     * @notice Lets a pauser of the protocol undo a previously implemented emergency stop.
+     */
+    function unpauseLiquidations() public virtual onlyPauser {
+         liquidationsPaused = false;
+    }
+
+
 
     function addPauser(address _pauser) public virtual onlyOwner   {
        pauserRoleBearer[_pauser] = true;
@@ -747,7 +772,7 @@ contract TellerV2 is
 
 
     function lenderCloseLoan(uint256 _bidId)
-        external whenNotPaused
+        external whenNotPaused whenLiquidationsNotPaused
         acceptedLoan(_bidId, "lenderClaimCollateral")
     {
         Bid storage bid = bids[_bidId];
@@ -763,7 +788,7 @@ contract TellerV2 is
     function lenderCloseLoanWithRecipient(
         uint256 _bidId,
         address _collateralRecipient
-    ) external whenNotPaused {
+    ) external whenNotPaused whenLiquidationsNotPaused {
         _lenderCloseLoanWithRecipient(_bidId, _collateralRecipient);
     }
 
@@ -790,7 +815,7 @@ contract TellerV2 is
      * @param _bidId The id of the loan to make the payment towards.
      */
     function liquidateLoanFull(uint256 _bidId)
-        external whenNotPaused
+        external whenNotPaused whenLiquidationsNotPaused
         acceptedLoan(_bidId, "liquidateLoan")
     {
         Bid storage bid = bids[_bidId];
@@ -802,7 +827,7 @@ contract TellerV2 is
     }
 
     function liquidateLoanFullWithRecipient(uint256 _bidId, address _recipient)
-        external whenNotPaused
+        external whenNotPaused whenLiquidationsNotPaused
         acceptedLoan(_bidId, "liquidateLoan")
     {
         _liquidateLoanFull(_bidId, _recipient);

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -745,7 +745,7 @@ contract TellerV2 is
 
 
     function lenderCloseLoan(uint256 _bidId)
-        external
+        external whenNotPaused
         acceptedLoan(_bidId, "lenderClaimCollateral")
     {
         Bid storage bid = bids[_bidId];
@@ -761,7 +761,7 @@ contract TellerV2 is
     function lenderCloseLoanWithRecipient(
         uint256 _bidId,
         address _collateralRecipient
-    ) external {
+    ) external whenNotPaused {
         _lenderCloseLoanWithRecipient(_bidId, _collateralRecipient);
     }
 
@@ -788,7 +788,7 @@ contract TellerV2 is
      * @param _bidId The id of the loan to make the payment towards.
      */
     function liquidateLoanFull(uint256 _bidId)
-        external
+        external whenNotPaused
         acceptedLoan(_bidId, "liquidateLoan")
     {
         Bid storage bid = bids[_bidId];
@@ -800,7 +800,7 @@ contract TellerV2 is
     }
 
     function liquidateLoanFullWithRecipient(uint256 _bidId, address _recipient)
-        external
+        external whenNotPaused
         acceptedLoan(_bidId, "liquidateLoan")
     {
         _liquidateLoanFull(_bidId, _recipient);
@@ -885,6 +885,8 @@ contract TellerV2 is
 
             // If loan is is being liquidated and backed by collateral, withdraw and send to borrower
             if (_shouldWithdrawCollateral) {
+
+                require( paused() == false, "Cannot withdraw collateral while protocol is paused." );
                 //   _getCollateralManagerForBid(_bidId).withdraw(_bidId);
                 collateralManager.withdraw(_bidId);
             }

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -741,7 +741,9 @@ contract TellerV2 is
     }
 
 
-
+    function isPauser(address _account) public view returns(bool){
+        return pauserRoleBearer[_account] ;
+    }
 
 
     function lenderCloseLoan(uint256 _bidId)

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -453,7 +453,7 @@ contract TellerV2 is
      * @notice Function for a market owner to cancel a bid in the market.
      * @param _bidId The id of the bid to cancel.
      */
-  /*  function marketOwnerCancelBid(uint256 _bidId) external {
+    function marketOwnerCancelBid(uint256 _bidId) external {
         if (
             _msgSender() !=
             marketRegistry.getMarketOwner(bids[_bidId].marketplaceId)
@@ -466,7 +466,7 @@ contract TellerV2 is
         }
         _cancelBid(_bidId);
         emit MarketOwnerCancelledBid(_bidId);
-    }*/
+    }
 
     /**
      * @notice Function for users to cancel a bid.

--- a/packages/contracts/contracts/TellerV2Storage.sol
+++ b/packages/contracts/contracts/TellerV2Storage.sol
@@ -162,4 +162,8 @@ abstract contract TellerV2Storage_G6 is TellerV2Storage_G5 {
     mapping(uint256 => address) public repaymentListenerForBid;
 }
 
-abstract contract TellerV2Storage is TellerV2Storage_G6 {}
+abstract contract TellerV2Storage_G7 is TellerV2Storage_G6 {
+    mapping(address => bool) public pauserRoleBearer;
+}
+
+abstract contract TellerV2Storage is TellerV2Storage_G7 {}

--- a/packages/contracts/contracts/TellerV2Storage.sol
+++ b/packages/contracts/contracts/TellerV2Storage.sol
@@ -164,6 +164,7 @@ abstract contract TellerV2Storage_G6 is TellerV2Storage_G5 {
 
 abstract contract TellerV2Storage_G7 is TellerV2Storage_G6 {
     mapping(address => bool) public pauserRoleBearer;
+    bool public liquidationsPaused;
 }
 
 abstract contract TellerV2Storage is TellerV2Storage_G7 {}

--- a/packages/contracts/contracts/interfaces/ITellerV2.sol
+++ b/packages/contracts/contracts/interfaces/ITellerV2.sol
@@ -171,4 +171,7 @@ interface ITellerV2 {
 
 
     function getEscrowVault() external view returns(address);
+
+
+    function isPauser(address _account) external view returns(bool);
 }

--- a/packages/contracts/contracts/mock/TellerV2SolMock.sol
+++ b/packages/contracts/contracts/mock/TellerV2SolMock.sol
@@ -19,6 +19,7 @@ contract TellerV2SolMock is ITellerV2, IProtocolFee, TellerV2Storage , ILoanRepa
     uint256 public amountOwedMockPrincipal;
     uint256 public amountOwedMockInterest;
       address public approvedForwarder;
+    bool public isPausedMock;
 
 
     PaymentCycleType globalBidPaymentCycleType = PaymentCycleType.Seconds;
@@ -42,6 +43,11 @@ contract TellerV2SolMock is ITellerV2, IProtocolFee, TellerV2Storage , ILoanRepa
 
     function getEscrowVault() external view returns(address){
         return address(0);
+    }
+
+
+    function paused() external view returns(bool){
+        return isPausedMock;
     }
 
 

--- a/packages/contracts/contracts/mock/TellerV2SolMock.sol
+++ b/packages/contracts/contracts/mock/TellerV2SolMock.sol
@@ -51,6 +51,10 @@ contract TellerV2SolMock is ITellerV2, IProtocolFee, TellerV2Storage , ILoanRepa
     }
 
 
+    function isPauser(address _account) public view returns(bool){
+        return false; //for now 
+    }
+
     function approveMarketForwarder(uint256 _marketId, address _forwarder)
         external
     {

--- a/packages/contracts/tests/LenderCommitmentForwarder/extensions/SmartCommitments/LenderCommitmentGroup_Smart_Test.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder/extensions/SmartCommitments/LenderCommitmentGroup_Smart_Test.sol
@@ -59,6 +59,7 @@ contract LenderCommitmentGroup_Smart_Test is Testable {
 
         _tellerV2 = new TellerV2SolMock();
         _smartCommitmentForwarder = new SmartCommitmentForwarder();
+         
         _uniswapV3Pool = new UniswapV3PoolMock();
 
         _uniswapV3Factory = new UniswapV3FactoryMock();
@@ -1080,4 +1081,10 @@ function test_liquidateDefaultedLoanWithIncentive_does_not_double_count_repaid()
 
 contract User {}
 
-contract SmartCommitmentForwarder {}
+contract SmartCommitmentForwarder {
+
+    function paused() external returns (bool){
+        return false;
+    }
+
+}

--- a/packages/contracts/tests/TellerV2/TellerV2_pause.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_pause.sol
@@ -26,7 +26,7 @@ contract TellerV2_pause_test is Testable {
     }
 
     function test_pauseProtocol_invalid_if_not_owner() public {
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert("Requires role: Pauser");
 
         tellerV2.pauseProtocol();
     }


### PR DESCRIPTION
Adds pauser role to TellerV2.sol.  This means that the Owner can appoint 'pausers' who are able to pause and unpause TellerV2.sol and SmartCommitmentForwarder.  

When the protocol is paused, now: 

- collateral cannot be withdrawn


Also, the SmartCommitmentForwarder can be paused.  When the SCF is paused, in any child Lender Groups:

- shares cannot be minted or burned 
 